### PR TITLE
Verificar resposta da aplicação na porta 3000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ensaio-fotos",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.864.0",
         "@next-auth/prisma-adapter": "^1.0.7",


### PR DESCRIPTION
Update `package-lock.json` to include `hasInstallScript` flag.

This change reflects the updated state of the project's dependencies after `npm install` was executed to prepare the environment for verifying the application's response on port 3000.

---
<a href="https://cursor.com/background-agent?bcId=bc-b57c043c-28f2-452f-bf28-aab25a0b2ec9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b57c043c-28f2-452f-bf28-aab25a0b2ec9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

